### PR TITLE
(MAINT) Use logrus for all logging

### DIFF
--- a/pkg/waitfor/waitfor.go
+++ b/pkg/waitfor/waitfor.go
@@ -17,7 +17,6 @@ package waitfor
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -78,7 +77,7 @@ func (h *Handler) Wait(options ...Options) error {
 	for name, check := range h.dependencies {
 		wg.Add(1)
 		go func(n string, c Check) {
-			log.Printf("Waiting for %s\n", n)
+			logrus.Infof("Waiting for %s\n", n)
 			if err := performCheck(n, c, *option); err != nil {
 				errorMessages <- err
 			} else {


### PR DESCRIPTION
The lib is printing to stdout.  We should use logrus so we can control the log level